### PR TITLE
Fix typo in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ keyword = st_tags_sidebar(
                  'eight', 'nine', 'three', 
                  'eleven', 'ten', 'four'],
     maxtags = 4,
-    key='1')
+    key='2')
 ```
 ## Sample Images of the UI:
 [![UI](https://user-images.githubusercontent.com/49101362/113942909-59494100-980a-11eb-8f4c-662f5c18d967.png)](https://share.streamlit.io/gagan3012/streamlit-tags/examples/app.py)


### PR DESCRIPTION
Avoid two widgets with the same key, as it causes a Streamlit error.

# Fixes

# Proposed Changes

